### PR TITLE
Updating never-ending-stream to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "main": "index.js",
   "dependencies": {
     "dockerode": "^2.2.2",
-    "never-ending-stream": "^1.1.2",
+    "never-ending-stream": "^2.0.0",
     "through2": "^2.0.0"
   },
   "repository": {


### PR DESCRIPTION
Original never-ending-stream uses through2 v0.6.5, which was leaking memory